### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy_website
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/dpup/ersn.net/security/code-scanning/1](https://github.com/dpup/ersn.net/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out the code) and does not require write access. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
