### PR TITLE
feat: add Murphy's net to Wednesday practice schedule

### DIFF
--- a/src/pages/nets.astro
+++ b/src/pages/nets.astro
@@ -32,15 +32,23 @@ const frontmatter = {
         <h3 class="text-xl font-serif text-stone-800">Schedule</h3>
       </div>
       <p class="text-stone-600 mb-4">
-        The ERSN net meets every <b
+        The ERSN net meets every Wednesday with the <b
           ><a
-            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Wednesday+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T200000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
+            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Arnold+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T193000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
 "
             target="_blank"
             title="Add to Google Calendar"
-            class="underline hover:text-red-700">Wednesday at 7 PM</a
+            class="underline hover:text-red-700">Arnold net at 7:00 PM</a
           ></b
-        > and <b
+        > followed by <b
+          ><a
+            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Murphy%27s+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T193000Z-800/20250101T200000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
+"
+            target="_blank"
+            title="Add to Google Calendar"
+            class="underline hover:text-red-700">Murphy's net at 7:30 PM</a
+          ></b
+        >, and <b
           ><a
             href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Saturday+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250104T090000Z-800/20250104T100000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=SA
 "


### PR DESCRIPTION
Update Wednesday schedule to include both Arnold net (7:00 PM) and Murphy's net (7:30 PM) with separate Google Calendar links for each. Maintains existing Saturday 9 AM schedule.

Closes #56

Generated with [Claude Code](https://claude.ai/code)