### PR TITLE
Fix practice net schedule section

### DIFF
--- a/src/pages/nets.astro
+++ b/src/pages/nets.astro
@@ -34,19 +34,19 @@ const frontmatter = {
       <p class="text-stone-600 mb-4">
         The ERSN hosts three weekly practice nets: <b
           ><a
-            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Arnold+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T193000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
-"
-            target="_blank"
-            title="Add to Google Calendar"
-            class="underline hover:text-red-700">Arnold net on Wednesday at 7:00 PM</a
-          ></b
-        >, <b
-          ><a
             href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Murphy%27s+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T200000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=MO
 "
             target="_blank"
             title="Add to Google Calendar"
             class="underline hover:text-red-700">Murphy's net on Monday at 7:00 PM</a
+          ></b
+        >, <b
+          ><a
+            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Arnold+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T193000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
+"
+            target="_blank"
+            title="Add to Google Calendar"
+            class="underline hover:text-red-700">Arnold net on Wednesday at 7:00 PM</a
           ></b
         >, and <b
           ><a

--- a/src/pages/nets.astro
+++ b/src/pages/nets.astro
@@ -32,21 +32,21 @@ const frontmatter = {
         <h3 class="text-xl font-serif text-stone-800">Schedule</h3>
       </div>
       <p class="text-stone-600 mb-4">
-        The ERSN net meets every Wednesday with the <b
+        The ERSN hosts three weekly practice nets: <b
           ><a
             href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Arnold+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T193000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=WE
 "
             target="_blank"
             title="Add to Google Calendar"
-            class="underline hover:text-red-700">Arnold net at 7:00 PM</a
+            class="underline hover:text-red-700">Arnold net on Wednesday at 7:00 PM</a
           ></b
-        > followed by <b
+        >, <b
           ><a
             href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Murphy%27s+Practice+Net&details=Weekly+practice+net+for+ERSN+participants.+All+are+welcome!+Frequency:+462.675+MHz+(Channel+20+/+Repeater+6)&location=Arnold+Summit+Repeater&dates=20250101T190000Z-800/20250101T200000Z-800&recur=RRULE:FREQ=WEEKLY;BYDAY=MO
 "
             target="_blank"
             title="Add to Google Calendar"
-            class="underline hover:text-red-700">Murphy's net at 7:00 PM</a
+            class="underline hover:text-red-700">Murphy's net on Monday at 7:00 PM</a
           ></b
         >, and <b
           ><a
@@ -54,7 +54,7 @@ const frontmatter = {
 "
             target="_blank"
             title="Add to Google Calendar"
-            class="underline hover:text-red-700">Saturday at 9 AM</a
+            class="underline hover:text-red-700">Arnold net on Saturday at 9:00 AM</a
           ></b
         >. We look forward to hearing from all participating members and visitors. For additional
         information, join us on our Facebook page or email us at <a


### PR DESCRIPTION
Corrects the practice net schedule section to clearly show three separate nets on different days.

Changes:
- Updated schedule text to clearly show Arnold nets on Wednesday 7pm and Saturday 9am
- Murphy's net clearly shown on Monday 7pm
- Removed confusing "every Wednesday with... followed by..." language
- All Google Calendar links maintained with correct scheduling

Resolves #64

Generated with [Claude Code](https://claude.ai/code)