### PR TITLE
Update homepage practice schedule to include Monday nets

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -169,7 +169,7 @@ const latestBulletins = bulletins
         <h3 class="text-xl font-serif text-stone-800">Practice Nets</h3>
       </div>
       <p class="text-stone-600 mb-4">
-        Join us every Wednesday night and Saturday morning for equipment testing and community
+        Join us every Monday, Wednesday, and Saturday for equipment testing and community
         updates. All licensed operators welcome. <a
           href="/nets"
           class="underline hover:text-red-700">Learn more</a


### PR DESCRIPTION
Updates homepage text to reflect that practice nets now occur on Monday, Wednesday, and Saturday instead of just Wednesday night and Saturday morning.

Resolves #64

Generated with [Claude Code](https://claude.ai/code)