### PR TITLE
Add new Preparation resources page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,7 @@ const resourceLinks = [
   { title: 'GMRS Guide', href: '/gmrs' },
   { title: 'Channels', href: '/channels' },
   { title: 'Meshtastic', href: '/mesh' },
+  { title: 'Preparation', href: '/prep' },
   { title: 'Burn Day Information', href: 'https://burnday.ersn.net' },
   { title: 'Emergency Contacts', href: '/emergency' },
   { title: 'Contact ERSN', href: 'mailto:ersnnets@gmail.com' },

--- a/src/pages/prep.astro
+++ b/src/pages/prep.astro
@@ -51,6 +51,38 @@ const frontmatter = {
       Wildfires spread fast, and every second counts. With Watch Duty, you can receive early warnings that allow you to take action before conditions worsen, potentially saving lives and property.
     </p>
 
+    <h2>Additional Recommendations for Fires and Storms</h2>
+    
+    <h3>1. Store Water</h3>
+    <p>
+      In the event of fires or storms, water sources may become contaminated or unavailable. Store at least one gallon of water per person per day for at least three days, with a focus on drinking and basic hygiene. You can use containers like jugs or bottles, ensuring that you have enough for drinking, cooking, and cleaning.
+    </p>
+
+    <h3>2. Emergency Food Supply</h3>
+    <p>
+      Stock up on non-perishable food items like canned goods, dry grains, and protein bars. A three-day supply of food for each person in your household is recommended. Ensure that these supplies are easily accessible and ready to go in case of evacuation.
+    </p>
+
+    <h3>3. Fire-Resistant Materials and Evacuation Plans</h3>
+    <p>
+      For those in fire-prone areas, ensure that you have a fire-resistant kit, including fireproof blankets, protective clothing, and masks. Make sure you know at least two evacuation routes and have a designated meeting point for family members.
+    </p>
+
+    <h3>4. Maintain a Grab-and-Go Bag</h3>
+    <p>
+      Pack an emergency bag with essential items such as a flashlight, extra batteries, important documents (in a waterproof container), first-aid supplies, and a multi-tool. Include any medications or medical supplies needed for you or your family members.
+    </p>
+
+    <h3>5. Secure Your Home</h3>
+    <p>
+      Ensure your home is equipped to withstand storms and fires. This includes clearing gutters, trimming trees that could become projectiles in high winds, and reinforcing windows or doors to protect against flying debris. For fire risks, ensure your property is defensible by removing dry brush and flammable materials.
+    </p>
+
+    <h3>6. Backup Power</h3>
+    <p>
+      Consider purchasing a portable power generator to keep essential electronics running (e.g., lights, radios, medical equipment). Have extra fuel stored safely and ensure your generator is in good working condition.
+    </p>
+
     <h2>How ERSN Fits Into Your Disaster Plan</h2>
     <p>
       ERSN's <strong>volunteer emergency communications network</strong> ensures that even when the phone lines go down, our community stays connected. Our GMRS repeaters cover areas along the Highway-4 corridor, enabling communication across a wide region. Join our weekly <strong>practice nets</strong> to familiarize yourself with procedures and meet fellow members.

--- a/src/pages/prep.astro
+++ b/src/pages/prep.astro
@@ -1,0 +1,88 @@
+---
+import Content from '@components/Content.astro';
+import Layout from '@layouts/Layout.astro';
+
+const frontmatter = {
+  title: 'Pre-Disaster Preparation',
+  description:
+    'Essential tools and resources for emergency preparedness, including alert systems, communication networks, and disaster planning guides.',
+};
+---
+
+<Layout frontmatter={frontmatter}>
+  <Content>
+    <h1>Pre-Disaster Preparation</h1>
+
+    <p>
+      When disaster strikes, staying connected is crucial. At <strong>Ebbetts' Radio Safety Net (ERSN)</strong>, we recognize the importance of preparedness in ensuring that vital communication lines remain open, especially when traditional systems fail. Whether it's wildfires, storms, or earthquakes, our volunteer-powered radio network, using GMRS radios, helps keep our community linked when it's needed most.
+    </p>
+
+    <h2>Why Pre-Disaster Preparation is Essential</h2>
+    <p>
+      Emergencies can happen at any time. By preparing ahead of time, you're not only protecting yourself and your family but also contributing to the safety and resilience of your community. Pre-disaster preparation includes knowing your risks, having a communication plan in place, and ensuring that you have access to timely information when it matters most.
+    </p>
+
+    <h2>Tools and Resources to Help You Prepare</h2>
+
+    <h3>1. Everbridge - Emergency Notifications</h3>
+    <p>
+      <a href="https://www.everbridge.com/use-cases/mass-notification-and-incident-communications/" target="_blank">Everbridge</a> offers a mass notification system that delivers urgent updates and emergency alerts directly to your phone, ensuring that you are aware of any ongoing threats in your area. Subscribing to Everbridge allows you to receive timely alerts about evacuations, severe weather, and other critical events, giving you time to act.
+    </p>
+    <p><strong>Why use it?</strong></p>
+    <p>
+      In times of disaster, receiving instant alerts can make a life-saving difference. Everbridge ensures that you don't miss vital information, especially during rapidly developing situations like wildfires or floods.
+    </p>
+
+    <h3>2. Genesys Protect - Know Your Zone</h3>
+    <p>
+      <a href="https://protect.genasys.com/search" target="_blank">Genesys Protect</a> allows you to search your zone and sign up for localized alerts, so you know what emergency risks you are facing. Whether it's fire, floods, or another disaster, you'll receive information tailored specifically to your location.
+    </p>
+    <p><strong>Why use it?</strong></p>
+    <p>
+      By understanding the unique risks in your area, you can tailor your emergency plans accordingly, including evacuation routes and safety protocols. This tool provides location-based alerts that are vital during emergency events.
+    </p>
+
+    <h3>3. Watch Duty - Early Fire Warning System</h3>
+    <p>
+      <a href="https://www.watchduty.org/" target="_blank">Watch Duty</a> provides early fire warnings through a collaborative, community-driven system. The system tracks fires and sends early alerts, helping you stay ahead of fire-related threats in your area.
+    </p>
+    <p><strong>Why use it?</strong></p>
+    <p>
+      Wildfires spread fast, and every second counts. With Watch Duty, you can receive early warnings that allow you to take action before conditions worsen, potentially saving lives and property.
+    </p>
+
+    <h2>How ERSN Fits Into Your Disaster Plan</h2>
+    <p>
+      ERSN's <strong>volunteer emergency communications network</strong> ensures that even when the phone lines go down, our community stays connected. Our GMRS repeaters cover areas along the Highway-4 corridor, enabling communication across a wide region. Join our weekly <strong>practice nets</strong> to familiarize yourself with procedures and meet fellow members.
+    </p>
+    <p><strong>Why use ERSN?</strong></p>
+    <p>
+      When disaster strikes, you need reliable communication to stay in touch with neighbors, emergency services, and others. Our volunteer network ensures that you have access to a backup communication system if traditional networks fail.
+    </p>
+
+    <h2>What You Can Do Now to Prepare:</h2>
+    <ol>
+      <li>
+        <strong>Get a GMRS License</strong><br>
+        Apply for your FCC GMRS license (no test required).
+      </li>
+      <li>
+        <strong>Get a Radio</strong><br>
+        Purchase a compatible GMRS radio from our recommended list.
+      </li>
+      <li>
+        <strong>Join a Practice Net</strong><br>
+        Attend weekly practice nets to learn emergency procedures and connect with other licensed operators.
+      </li>
+    </ol>
+
+    <p>
+      By using the tools and resources above and connecting with ERSN, you can take significant steps toward ensuring your family's safety during an emergency. Don't wait for the next disaster—start preparing now.
+    </p>
+
+    <h3>Stay Informed and Stay Safe</h3>
+    <p>
+      For more information on how ERSN can help you during a disaster, or to get started with GMRS radios, visit our <a href="/gmrs">Getting Started with GMRS Radios</a> page.
+    </p>
+  </Content>
+</Layout>


### PR DESCRIPTION
Adds a new preparation page at /prep with disaster preparedness information and resources.

## Changes
- Created new `src/pages/prep.astro` with emergency preparedness content
- Added "Preparation" link to resources dropdown menu in navigation
- Includes sections on alert systems, communication planning, and ERSN integration

Closes #73

Generated with [Claude Code](https://claude.ai/code)