### PR TITLE
Add preparation page link to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,6 +92,9 @@ const latestBulletins = bulletins
         volunteer-powered emergency communications network, using GMRS radios to keep our community
         linked when traditional systems fail.
       </p>
+      <p class="text-stone-500 text-sm">
+        <a href="/prep" class="text-stone-600 hover:text-red-700 hover:underline">Learn how to prepare for disasters →</a>
+      </p>
     </div>
 
     {/* Latest Bulletins */}


### PR DESCRIPTION
Adds a link to the new preparation page in the homepage welcome section.

## Changes
- Added smaller, fainter text with link to /prep below welcome message
- Link uses consistent hover styling with site theme
- Maintains existing welcome text unchanged

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)