### PR TITLE
Update Arnold Summit repeater status to operational

### DIFF
--- a/src/components/homepage/CurrentConditions.tsx
+++ b/src/components/homepage/CurrentConditions.tsx
@@ -71,7 +71,7 @@ interface Alert {
 
 const repeaters: RepeaterInfo[] = [
   { name: "Murphy's", frequency: '462.725', status: 'up' },
-  { name: 'Arnold Summit', frequency: '462.725', status: 'down' },
+  { name: 'Arnold Summit', frequency: '462.725', status: 'up' },
 ];
 
 const getWeatherIcon = (iconCode: string): ReactElement => {

--- a/src/pages/status.astro
+++ b/src/pages/status.astro
@@ -67,11 +67,11 @@ const frontmatter = {
           <div class="border border-stone-200 rounded-lg p-4">
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center space-x-2">
-                <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
+                <div class="w-3 h-3 bg-green-500 rounded-full"></div>
                 <h3 class="font-medium text-stone-800">Arnold Summit</h3>
               </div>
-              <span class="text-xs text-yellow-700 bg-yellow-100 px-2 py-1 rounded">
-                Intermittent
+              <span class="text-xs text-green-700 bg-green-100 px-2 py-1 rounded">
+                Operational
               </span>
             </div>
             <div class="text-sm text-stone-600">


### PR DESCRIPTION
Arnold Summit repeater is back online. Updated status in both the
homepage widget and the status page.

https://claude.ai/code/session_01CztnwnUYbtXCSbUGmZvT1H