### PR TITLE
Fix GRMS typo in practice nets heading

### DIFF
--- a/src/components/homepage/PracticeNetsSchedule.astro
+++ b/src/components/homepage/PracticeNetsSchedule.astro
@@ -18,7 +18,7 @@
         d="M9.348 14.652a3.75 3.75 0 0 1 0-5.304m5.304 0a3.75 3.75 0 0 1 0 5.304m-7.425 2.121a6.75 6.75 0 0 1 0-9.546m9.546 0a6.75 6.75 0 0 1 0 9.546M5.106 18.894c-3.808-3.807-3.808-9.98 0-13.788m13.788 0c3.808 3.807 3.808 9.98 0 13.788M12 12h.008v.008H12V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
       ></path>
     </svg>
-    <h3 class="text-xl font-serif text-blue-900">GRMS Practice Nets</h3>
+    <h3 class="text-xl font-serif text-blue-900">GMRS Practice Nets</h3>
   </div>
 
   <div class="flex-1 flex flex-col">


### PR DESCRIPTION
GMRS (General Mobile Radio Service) was misspelled as GRMS.