### PR TITLE
Rename Meshtastic nav entries to Mesh Comms

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const resourceLinks = [
   { title: 'GMRS Guide', href: '/gmrs' },
   { title: 'Radio Basics', href: '/resources/radio-basics' },
   { title: 'Channels', href: '/channels' },
-  { title: 'Meshtastic', href: '/mesh' },
+  { title: 'Mesh Comms', href: '/mesh' },
   { title: 'Emergency Net Playbook', href: '/resources/emergency-net-playbook' },
   { separator: true },
   { title: 'Preparation', href: '/prep' },
@@ -31,7 +31,7 @@ const footerLinks = [
   { title: 'GMRS Guide', href: '/gmrs' },
   { title: 'Practice Net', href: '/nets' },
   { title: 'Channels', href: '/channels' },
-  { title: 'Meshtastic', href: '/mesh' },
+  { title: 'Mesh Comms', href: '/mesh' },
   { title: 'Emergency Info', href: '/emergency' },
   { title: 'About ERSN', href: '/about' },
 ];


### PR DESCRIPTION
Follow-up to #182. Updates the navigation to match the renamed mesh comms page.

- Renames the **Meshtastic** entry to **Mesh Comms** in the resource menu and the footer links in `src/layouts/Layout.astro`.
- Both still point to `/mesh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iaUkWK6nbmysmyK1YQKNg

---
_Generated by [Claude Code](https://claude.ai/code/session_016iaUkWK6nbmysmyK1YQKNg)_