### PR TITLE
Migrate to S.I.E.R.R.A. Grid /api/v1 unified event feed

### DIFF
--- a/src/components/RoadWeatherStatus.tsx
+++ b/src/components/RoadWeatherStatus.tsx
@@ -10,17 +10,29 @@ import {
   Eye,
   AlertTriangle,
   CheckCircle,
+  Clock,
   MapPin,
   CircleAlert,
   OctagonX,
+  Link,
 } from 'lucide-react';
+import RouteDetailsDialog from './RouteDetailsDialog';
 import WeatherDetailsDialog from './WeatherDetailsDialog';
 import AlertDetailsDialog from './AlertDetailsDialog';
-import { type Alert, type WeatherLocation, formatHumanTime, formatEnumValue } from './types';
+import {
+  type Alert,
+  type RoadSegment,
+  type ChainControlInfo,
+  type WeatherLocation,
+  formatHumanTime,
+} from './types';
 
 // API Response Interfaces — S.I.E.R.R.A. Grid /api/v1 (camelCase fields).
-// Weather is served by /conditions; road incidents and weather alerts are both
-// events on the unified event feed (/events?layer=…).
+//   • Weather is served by /conditions.
+//   • Road *state* (open/restricted/closed, travel time, delay) is the
+//     road_segment map-layer projection; chain control is the chain_control
+//     projection — both GeoJSON FeatureCollections.
+//   • Road *incidents* and weather alerts are events on the unified event feed.
 interface WeatherConditionsApi {
   locationId?: string;
   locationName?: string;
@@ -47,8 +59,53 @@ interface ConditionsResponse {
   lastUpdated?: string;
 }
 
-// The common event envelope carries everything a card needs; the typed detail
-// blocks (roadIncident / weatherAlert) add the kind-specific fields.
+// road_segment.geojson feature properties.
+interface RoadSegmentProps {
+  id?: string;
+  headline?: string;
+  status?: string; // OPEN | RESTRICTED | CLOSED
+  areaLabel?: string;
+  description?: string;
+  severity?: string;
+  road?: {
+    roadId?: string;
+    congestion?: string;
+    delayMinutes?: number;
+    durationMinutes?: number;
+    distanceKm?: number;
+  };
+}
+
+// chain_control.geojson feature properties. The chain layer is empty outside
+// winter and its typed block is not in the OpenAPI spec, so we read the level
+// defensively from whichever field carries it.
+interface ChainControlProps {
+  id?: string;
+  headline?: string;
+  areaLabel?: string;
+  status?: string;
+  category?: string;
+  description?: string;
+  effective?: string;
+  level?: string;
+  road?: { roadId?: string };
+  chainControl?: {
+    level?: string;
+    direction?: string;
+    effectiveTime?: string;
+    locationName?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+}
+
+interface GeoJsonFeatureCollection<P> {
+  type?: string;
+  features?: { type?: string; properties?: P }[];
+  metadata?: { generatedAt?: string; sourceStatus?: string };
+}
+
+// The common event envelope + typed detail blocks.
 interface GridEvent {
   id?: string;
   layer?: string;
@@ -60,6 +117,7 @@ interface GridEvent {
   description?: string;
   areaLabel?: string;
   canonicalUrl?: string;
+  placeIds?: string[];
   effective?: string;
   expires?: string;
   observedAt?: string;
@@ -85,7 +143,7 @@ interface GridEventList {
 }
 
 interface ApiData {
-  roadIncidents: Alert[];
+  roads: RoadSegment[];
   weather: WeatherLocation[];
   alerts: Alert[];
   lastUpdated: string;
@@ -136,17 +194,34 @@ const getWeatherIcon = (iconCode: string) => {
   return iconMap[iconCode] || <Cloud className="h-5 w-5 text-gray-500" />;
 };
 
-const getIncidentIcon = (alert: Alert) => {
-  const category = (alert.incidentType || '').toLowerCase();
-  const isClosure = category.includes('closure') || category.includes('closed');
+const getRoadStatusIcon = (status: string) => {
+  switch (status) {
+    case 'clear':
+      return <CheckCircle className="h-5 w-5 text-green-600" />;
+    case 'delays':
+      return <Clock className="h-5 w-5 text-yellow-600" />;
+    case 'restrictions':
+      return <CircleAlert className="h-5 w-5 text-yellow-600" />;
+    case 'closed':
+      return <OctagonX className="h-5 w-5 text-red-600" />;
+    default:
+      return <CheckCircle className="h-5 w-5 text-green-600" />;
+  }
+};
 
-  if (alert.severity === 'CRITICAL' || isClosure) {
-    return <OctagonX className="h-5 w-5 text-red-600" />;
+const getRoadStatusText = (segment: RoadSegment) => {
+  switch (segment.status) {
+    case 'clear':
+      return 'Clear';
+    case 'delays':
+      return segment.delayMinutes ? `${segment.delayMinutes} min delays` : 'Delays';
+    case 'restrictions':
+      return segment.delayMinutes ? `${segment.delayMinutes} min delays` : 'Restrictions';
+    case 'closed':
+      return 'Closed';
+    default:
+      return 'Unknown';
   }
-  if (alert.severity === 'WARNING') {
-    return <CircleAlert className="h-5 w-5 text-yellow-600" />;
-  }
-  return <AlertTriangle className="h-5 w-5 text-blue-600" />;
 };
 
 // S.I.E.R.R.A. Grid data feeds.
@@ -167,6 +242,15 @@ const mapGridSeverity = (severity: string | undefined): Alert['severity'] => {
     default:
       return 'INFO';
   }
+};
+
+// Detect an R1/R2/R3 chain level from whichever free-text field carries it.
+const detectChainLevel = (...values: (string | undefined)[]): ChainControlInfo['level'] => {
+  const s = values.filter(Boolean).join(' ').toUpperCase();
+  if (/\bR3\b/.test(s)) return 'CHAIN_CONTROL_LEVEL_R3';
+  if (/\bR2\b/.test(s)) return 'CHAIN_CONTROL_LEVEL_R2';
+  if (/\bR1\b/.test(s)) return 'CHAIN_CONTROL_LEVEL_R1';
+  return 'CHAIN_CONTROL_LEVEL_NONE';
 };
 
 // A road_incident Grid event → display Alert. The incident type is the envelope
@@ -238,10 +322,44 @@ const transformFireWeather = (fw: FireWeatherConditions | undefined): Alert | nu
   };
 };
 
+// Build a roadId → chain-control map from the chain_control layer.
+const buildChainControlMap = (
+  fc: GeoJsonFeatureCollection<ChainControlProps> | undefined,
+): Record<string, ChainControlInfo> => {
+  const map: Record<string, ChainControlInfo> = {};
+  for (const feature of fc?.features || []) {
+    const p = feature.properties;
+    if (!p) continue;
+    const roadId = p.road?.roadId || (p.id || '').replace(/^[^:]+:/, '');
+    if (!roadId) continue;
+    const level = detectChainLevel(
+      p.chainControl?.level,
+      p.level,
+      p.category,
+      p.status,
+      p.headline,
+    );
+    if (level === 'CHAIN_CONTROL_LEVEL_NONE' || level === 'CHAIN_CONTROL_LEVEL_UNSPECIFIED') {
+      continue;
+    }
+    map[roadId] = {
+      level,
+      locationName: p.chainControl?.locationName || p.areaLabel || p.headline,
+      latitude: p.chainControl?.latitude,
+      longitude: p.chainControl?.longitude,
+      direction: p.chainControl?.direction,
+      effectiveTime: p.chainControl?.effectiveTime || p.effective,
+      description: p.description,
+    };
+  }
+  return map;
+};
+
 export default function RoadWeatherStatus() {
   const [data, setData] = useState<ApiData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedRoute, setSelectedRoute] = useState<RoadSegment | null>(null);
   const [selectedWeather, setSelectedWeather] = useState<WeatherLocation | null>(null);
   const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 
@@ -249,8 +367,19 @@ export default function RoadWeatherStatus() {
     try {
       setError(null);
 
-      const [conditionsResponse, roadIncidentsResponse, weatherAlertsResponse] = await Promise.all([
-        fetch(`${GRID_API_BASE}/conditions?place=${GRID_AREA}`, {
+      const [
+        conditionsResponse,
+        roadSegmentsResponse,
+        chainControlResponse,
+        roadIncidentsResponse,
+        weatherAlertsResponse,
+      ] = await Promise.all([
+        fetch(`${GRID_API_BASE}/conditions?place=${GRID_AREA}`, { method: 'GET', mode: 'cors' }),
+        fetch(`${GRID_API_BASE}/places/${GRID_AREA}/map/road_segment.geojson`, {
+          method: 'GET',
+          mode: 'cors',
+        }),
+        fetch(`${GRID_API_BASE}/places/${GRID_AREA}/map/chain_control.geojson`, {
           method: 'GET',
           mode: 'cors',
         }),
@@ -264,9 +393,17 @@ export default function RoadWeatherStatus() {
         }),
       ]);
 
-      if (!conditionsResponse.ok || !roadIncidentsResponse.ok || !weatherAlertsResponse.ok) {
+      if (
+        !conditionsResponse.ok ||
+        !roadSegmentsResponse.ok ||
+        !chainControlResponse.ok ||
+        !roadIncidentsResponse.ok ||
+        !weatherAlertsResponse.ok
+      ) {
         const errorDetails = {
           conditions: `${conditionsResponse.status} ${conditionsResponse.statusText}`,
+          roadSegments: `${roadSegmentsResponse.status} ${roadSegmentsResponse.statusText}`,
+          chainControl: `${chainControlResponse.status} ${chainControlResponse.statusText}`,
           roadIncidents: `${roadIncidentsResponse.status} ${roadIncidentsResponse.statusText}`,
           weatherAlerts: `${weatherAlertsResponse.status} ${weatherAlertsResponse.statusText}`,
         };
@@ -274,6 +411,10 @@ export default function RoadWeatherStatus() {
       }
 
       const conditions: ConditionsResponse = await conditionsResponse.json();
+      const roadSegments: GeoJsonFeatureCollection<RoadSegmentProps> =
+        await roadSegmentsResponse.json();
+      const chainControls: GeoJsonFeatureCollection<ChainControlProps> =
+        await chainControlResponse.json();
       const roadIncidentEvents: GridEventList = await roadIncidentsResponse.json();
       const weatherAlertEvents: GridEventList = await weatherAlertsResponse.json();
 
@@ -284,9 +425,14 @@ export default function RoadWeatherStatus() {
       const fireWeatherAlert = transformFireWeather(conditions.fireWeather);
       if (fireWeatherAlert) allAlerts.push(fireWeatherAlert);
 
-      // Road incidents are events on the road_incident layer.
-      const roadIncidents: Alert[] = (roadIncidentEvents.events || []).map(transformRoadIncident);
-      allAlerts.push(...roadIncidents);
+      // Road incidents are events on the road_incident layer. Keep the raw event
+      // alongside the transformed alert so we can attach incidents to the road
+      // segment they occur on (via the corridor:<roadId> place id).
+      const roadIncidents = (roadIncidentEvents.events || []).map((event) => ({
+        event,
+        alert: transformRoadIncident(event),
+      }));
+      allAlerts.push(...roadIncidents.map((r) => r.alert));
 
       // Weather alerts are area-wide events; one alert can cover several zones, so
       // dedupe by title. The deduped set is shown against every weather location.
@@ -300,8 +446,65 @@ export default function RoadWeatherStatus() {
         });
       allAlerts.push(...weatherAlerts);
 
+      const chainControlMap = buildChainControlMap(chainControls);
+
       const transformedData: ApiData = {
-        roadIncidents,
+        roads: (roadSegments.features || []).map((feature) => {
+          const p = feature.properties || {};
+          const roadId = p.road?.roadId || (p.id || '').replace(/^[^:]+:/, '');
+          const areaLabel = p.areaLabel || p.headline || '';
+
+          // Parse the areaLabel to extract from/to (e.g. "Angels Camp to Murphys")
+          const sectionParts = areaLabel.split(' to ');
+          const from = sectionParts[0] || p.headline || 'Route';
+          const to = sectionParts[1] || 'Destination';
+
+          const rawStatus = (p.status || '').toLowerCase();
+          const delayMinutes = p.road?.delayMinutes ?? 0;
+
+          // Incidents on this corridor become the segment's ON_ROUTE alerts.
+          const roadAlerts: Alert[] = roadIncidents
+            .filter((r) => (r.event.placeIds || []).includes(`corridor:${roadId}`))
+            .map((r) => ({ ...r.alert, classification: 'ON_ROUTE' as const }));
+
+          const chainControlInfo = roadId ? chainControlMap[roadId] : undefined;
+          const chainControlShort = chainControlInfo
+            ? chainControlInfo.level.replace('CHAIN_CONTROL_LEVEL_', '')
+            : 'none';
+          const hasChainControl = chainControlShort !== 'none';
+
+          // Map raw status + signals to our 4-level display status.
+          let status: 'clear' | 'delays' | 'restrictions' | 'closed' = 'clear';
+          if (rawStatus === 'closed') {
+            status = 'closed';
+          } else if (roadAlerts.some((alert) => alert.severity === 'CRITICAL')) {
+            status = 'restrictions';
+          } else if (rawStatus === 'restricted') {
+            status = 'restrictions';
+          } else if (delayMinutes > 0) {
+            status = 'delays';
+          } else if (hasChainControl) {
+            status = 'restrictions';
+          }
+
+          return {
+            from,
+            to,
+            status,
+            delayMinutes: p.road?.delayMinutes,
+            description: hasChainControl ? `Chain control: ${chainControlShort}` : undefined,
+            alertCount: roadAlerts.length,
+            alerts: roadAlerts,
+            // Additional metadata
+            congestionLevel: p.road?.congestion,
+            durationMinutes: p.road?.durationMinutes,
+            distanceKm: p.road?.distanceKm,
+            chainControl: chainControlShort,
+            chainControlInfo,
+            rawStatus: p.status,
+            statusExplanation: p.description,
+          };
+        }),
         weather: (conditions.weather || []).map((w) => ({
           name: w.locationName || w.locationId || 'Unknown',
           temperature: Math.round(((w.temperatureCelsius ?? 0) * 9) / 5 + 32), // Convert to Fahrenheit
@@ -332,7 +535,8 @@ export default function RoadWeatherStatus() {
             };
             return severityOrder[a.severity] - severityOrder[b.severity];
           }),
-        lastUpdated: conditions.lastUpdated || new Date().toISOString(),
+        lastUpdated:
+          conditions.lastUpdated || roadSegments.metadata?.generatedAt || new Date().toISOString(),
       };
 
       setData(transformedData);
@@ -470,43 +674,66 @@ export default function RoadWeatherStatus() {
             </div>
 
             <div className="space-y-1">
-              {data.roadIncidents.length === 0 ? (
-                <div className="flex items-center space-x-2 py-3 px-2">
-                  <CheckCircle className="h-5 w-5 text-green-600 flex-shrink-0" />
-                  <span className="text-sm text-stone-600">No active road incidents reported.</span>
-                </div>
+              {data.roads.length === 0 ? (
+                <p className="text-stone-600 text-sm italic">No road data available</p>
               ) : (
-                data.roadIncidents.map((incident, index) => {
-                  const categoryLabel = formatEnumValue(incident.incidentType);
-                  const title = incident.location || incident.title;
-                  const showHeadline = incident.title && incident.title !== title;
+                data.roads.map((segment) => {
+                  const roadKey = `${segment.from}-${segment.to}`;
 
                   return (
-                    <div
-                      key={incident.id || `incident-${index}`}
-                      className="border-b border-stone-100 last:border-b-0"
-                    >
+                    <div key={roadKey} className="border-b border-stone-100 last:border-b-0">
                       <button
                         type="button"
-                        onClick={() => setSelectedAlert(incident)}
+                        onClick={() => setSelectedRoute(segment)}
                         className="w-full cursor-pointer flex items-center justify-between py-3 px-2 hover:bg-stone-50 transition-colors rounded-sm touch-manipulation"
                       >
                         <div className="flex items-center space-x-3 flex-1 min-w-0">
-                          {getIncidentIcon(incident)}
+                          {getRoadStatusIcon(segment.status)}
                           <div className="text-left flex-1 min-w-0">
-                            <div className="font-medium text-stone-800 truncate">{title}</div>
-                            {showHeadline && (
-                              <div className="text-xs text-stone-500 truncate">
-                                {incident.title}
-                              </div>
-                            )}
+                            <div className="flex items-center space-x-2">
+                              <span className="font-medium text-stone-800 truncate">
+                                {segment.from} → {segment.to}
+                              </span>
+                              {/* Chain Control Icon */}
+                              {segment.chainControlInfo &&
+                                segment.chainControlInfo.level !== 'CHAIN_CONTROL_LEVEL_NONE' &&
+                                segment.chainControlInfo.level !==
+                                  'CHAIN_CONTROL_LEVEL_UNSPECIFIED' && (
+                                  <div
+                                    className="flex items-center flex-shrink-0 text-blue-600"
+                                    title="Chain control in effect"
+                                  >
+                                    <Link className="h-4 w-4" />
+                                  </div>
+                                )}
+                              {segment.alertCount > 0 &&
+                                (() => {
+                                  const onRouteAlerts = segment.alerts.filter(
+                                    (alert) => alert.classification === 'ON_ROUTE',
+                                  );
+                                  const hasOnRoute = onRouteAlerts.length > 0;
+
+                                  return (
+                                    <div
+                                      className={`flex items-center space-x-1 flex-shrink-0 ${
+                                        hasOnRoute ? 'text-red-600' : 'text-yellow-600'
+                                      }`}
+                                    >
+                                      <AlertTriangle className="h-4 w-4" />
+                                      {hasOnRoute && (
+                                        <span className="text-xs font-medium bg-red-100 px-1.5 py-0.5 rounded">
+                                          {onRouteAlerts.length > 9 ? '9+' : onRouteAlerts.length}
+                                        </span>
+                                      )}
+                                    </div>
+                                  );
+                                })()}
+                            </div>
                           </div>
                         </div>
-                        {categoryLabel && (
-                          <div className="text-sm text-stone-600 flex-shrink-0 ml-2 capitalize">
-                            {categoryLabel}
-                          </div>
-                        )}
+                        <div className="text-sm text-stone-600 flex-shrink-0 ml-2">
+                          {getRoadStatusText(segment)}
+                        </div>
                       </button>
                     </div>
                   );
@@ -550,7 +777,7 @@ export default function RoadWeatherStatus() {
         </div>
         <div className="m-4 p-3 bg-stone-50 rounded border border-stone-200">
           <p className="text-xs text-stone-600 text-center">
-            <strong>Source:</strong> Caltrans / CHP • OpenWeather • NWS
+            <strong>Source:</strong> Google Routes • Caltrans / CHP • OpenWeather • NWS
             <br />
             <strong>Last Updated:</strong> {formatHumanTime(data.lastUpdated)} •{' '}
             <strong>Update Frequency:</strong> Every 15 minutes
@@ -568,6 +795,11 @@ export default function RoadWeatherStatus() {
           </p>
         </div>
       </div>
+
+      {/* Route Details Dialog */}
+      {selectedRoute && (
+        <RouteDetailsDialog selectedRoute={selectedRoute} onClose={() => setSelectedRoute(null)} />
+      )}
 
       {/* Weather Details Dialog */}
       {selectedWeather && (

--- a/src/components/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog.tsx
@@ -1,0 +1,461 @@
+import {
+  Construction,
+  Ban,
+  Truck,
+  Snowflake,
+  CheckCircle,
+  AlertTriangle,
+  Link,
+  MapPin,
+  Clock,
+  ArrowRight,
+} from 'lucide-react';
+import Dialog, {
+  DialogHeader,
+  DialogContent,
+  StatBox,
+  InfoCard,
+  Badge,
+  CollapsibleSection,
+} from './Dialog';
+import {
+  type Alert,
+  type RoadSegment,
+  type ChainControlInfo,
+  formatHumanTime,
+  formatEnumValue,
+} from './types';
+
+interface RouteDetailsDialogProps {
+  selectedRoute: RoadSegment;
+  onClose: () => void;
+}
+
+// Helper functions
+const formatMetadataValue = (value: string): string => {
+  const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+  if (isoDateRegex.test(value)) {
+    return formatHumanTime(value) || value;
+  }
+  return formatEnumValue(value);
+};
+
+const getChainControlDisplay = (info: ChainControlInfo) => {
+  const levelMap: Record<string, { label: string; color: string; description: string }> = {
+    CHAIN_CONTROL_LEVEL_R1: {
+      label: 'R1',
+      color: 'bg-yellow-600 text-white',
+      description: 'Chains required except for vehicles with snow tires',
+    },
+    CHAIN_CONTROL_LEVEL_R2: {
+      label: 'R2',
+      color: 'bg-orange-600 text-white',
+      description: 'Chains required except 4WD/AWD with snow tires on all wheels',
+    },
+    CHAIN_CONTROL_LEVEL_R3: {
+      label: 'R3',
+      color: 'bg-red-600 text-white',
+      description: 'Chains required on all vehicles, no exceptions',
+    },
+  };
+  return levelMap[info.level] || null;
+};
+
+const getIncidentChip = (alert: Alert) => {
+  const type = alert.incidentType?.toLowerCase() || '';
+
+  if (type.includes('closure') || type.includes('closed')) {
+    return { label: 'Closure', color: 'bg-red-100 text-red-800', icon: Ban };
+  } else if (type.includes('construction') || type.includes('work')) {
+    return { label: 'Construction', color: 'bg-orange-100 text-orange-800', icon: Construction };
+  } else if (type.includes('hazard') || type.includes('debris')) {
+    return { label: 'Hazard', color: 'bg-yellow-100 text-yellow-800', icon: AlertTriangle };
+  } else if (type.includes('weather') || type.includes('snow') || type.includes('ice')) {
+    return { label: 'Weather', color: 'bg-blue-100 text-blue-800', icon: Snowflake };
+  } else if (type.includes('vehicle') || type.includes('accident') || type.includes('collision')) {
+    return { label: 'Incident', color: 'bg-purple-100 text-purple-800', icon: Truck };
+  }
+
+  if (alert.severity === 'CRITICAL') {
+    return { label: 'Critical', color: 'bg-red-100 text-red-800', icon: AlertTriangle };
+  } else if (alert.severity === 'WARNING') {
+    return { label: 'Warning', color: 'bg-orange-100 text-orange-800', icon: AlertTriangle };
+  } else {
+    return { label: 'Info', color: 'bg-blue-100 text-blue-800', icon: AlertTriangle };
+  }
+};
+
+const getImpactChip = (impact: string | undefined) => {
+  if (!impact) return null;
+
+  const impactLower = impact.toLowerCase();
+  if (impactLower.includes('severe') || impactLower.includes('major')) {
+    return { label: 'Severe impact', color: 'bg-red-100 text-red-800' };
+  } else if (impactLower.includes('moderate')) {
+    return { label: 'Moderate impact', color: 'bg-orange-100 text-orange-800' };
+  } else if (impactLower.includes('light') || impactLower.includes('minor')) {
+    return { label: 'Light impact', color: 'bg-yellow-100 text-yellow-800' };
+  }
+  return { label: formatEnumValue(impact), color: 'bg-gray-100 text-gray-800' };
+};
+
+// Helper function to calculate average speed
+const calculateAverageSpeed = (
+  distanceKm: number | undefined,
+  durationMinutes: number | undefined,
+): number | null => {
+  if (!distanceKm || !durationMinutes || durationMinutes === 0) return null;
+
+  const speedKmh = (distanceKm / durationMinutes) * 60;
+  const speedMph = speedKmh * 0.621371;
+
+  return Math.round(speedMph);
+};
+
+const formatDistanceToRoute = (distanceMeters: number | undefined): string => {
+  if (!distanceMeters) return '';
+
+  const distanceMiles = distanceMeters * 0.000621371;
+
+  if (distanceMiles < 0.1) {
+    return 'Very close';
+  } else if (distanceMiles < 1) {
+    return `${(distanceMiles * 5280).toFixed(0)} ft away`;
+  } else {
+    return `${distanceMiles.toFixed(1)} mi away`;
+  }
+};
+
+const getStatusBadgeVariant = (
+  status: string | undefined,
+): 'success' | 'warning' | 'critical' | 'muted' => {
+  if (!status) return 'muted';
+  const s = status.toLowerCase();
+  if (s === 'closed') return 'critical';
+  if (s === 'restricted' || s === 'restrictions') return 'warning';
+  return 'success';
+};
+
+export default function RouteDetailsDialog({ selectedRoute, onClose }: RouteDetailsDialogProps) {
+  const onRouteAlerts = selectedRoute.alerts.filter((alert) => alert.classification === 'ON_ROUTE');
+  const nearbyAlerts = selectedRoute.alerts.filter((alert) => alert.classification === 'NEARBY');
+
+  const distanceMi = selectedRoute.distanceKm
+    ? Math.round(selectedRoute.distanceKm * 0.621371)
+    : null;
+  const avgSpeed = calculateAverageSpeed(selectedRoute.distanceKm, selectedRoute.durationMinutes);
+  const durationMin = selectedRoute.durationMinutes
+    ? `~${Math.round(selectedRoute.durationMinutes)}`
+    : null;
+
+  const statsFooter = (
+    <div className="grid grid-cols-3 gap-3">
+      <StatBox label="miles" value={distanceMi ? String(distanceMi) : '—'} variant="dark" />
+      <StatBox label="avg mph" value={avgSpeed ? String(avgSpeed) : '—'} variant="dark" />
+      <StatBox label="min" value={durationMin || '—'} variant="dark" />
+    </div>
+  );
+
+  return (
+    <Dialog onClose={onClose} maxWidth="2xl">
+      {/* Dark header with route info */}
+      <DialogHeader onClose={onClose} variant="dark" footer={statsFooter}>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2.5 mb-3">
+            <span className="text-xl font-bold text-white truncate">{selectedRoute.from}</span>
+            <ArrowRight className="h-5 w-5 text-stone-400 flex-shrink-0" />
+            <span className="text-xl font-bold text-white truncate">{selectedRoute.to}</span>
+          </div>
+
+          {/* Status badges */}
+          <div className="flex flex-wrap gap-2">
+            {selectedRoute.rawStatus && (
+              <Badge variant={getStatusBadgeVariant(selectedRoute.rawStatus)}>
+                {formatEnumValue(selectedRoute.rawStatus)}
+              </Badge>
+            )}
+            {typeof selectedRoute.delayMinutes === 'number' && selectedRoute.delayMinutes > 0 && (
+              <span className="px-2.5 py-1 rounded-md text-xs font-semibold bg-amber-100/20 text-amber-200">
+                +{selectedRoute.delayMinutes} min delay
+              </span>
+            )}
+            {selectedRoute.congestionLevel && (
+              <span className="px-2.5 py-1 rounded-md text-xs font-medium bg-white/10 text-stone-300">
+                {formatEnumValue(selectedRoute.congestionLevel)} traffic
+              </span>
+            )}
+          </div>
+        </div>
+      </DialogHeader>
+
+      <DialogContent>
+        <div className="space-y-4">
+          {/* Chain Control Section */}
+          {selectedRoute.chainControlInfo &&
+            selectedRoute.chainControlInfo.level !== 'CHAIN_CONTROL_LEVEL_NONE' &&
+            selectedRoute.chainControlInfo.level !== 'CHAIN_CONTROL_LEVEL_UNSPECIFIED' && (
+              <InfoCard variant="warning">
+                <div className="flex gap-3">
+                  <div className="bg-yellow-600 rounded-lg w-9 h-9 flex items-center justify-center flex-shrink-0">
+                    <Link className="h-5 w-5 text-white" />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span className="text-sm font-bold text-yellow-900">Chain Control</span>
+                      {(() => {
+                        const display = getChainControlDisplay(selectedRoute.chainControlInfo!);
+                        return display ? (
+                          <span
+                            className={`px-1.5 py-0.5 text-[11px] font-bold rounded ${display.color}`}
+                          >
+                            {display.label}
+                          </span>
+                        ) : null;
+                      })()}
+                    </div>
+
+                    <p className="text-sm text-yellow-800 leading-relaxed">
+                      {selectedRoute.chainControlInfo.description ||
+                        getChainControlDisplay(selectedRoute.chainControlInfo)?.description}
+                    </p>
+
+                    <div className="flex flex-wrap gap-4 mt-3 text-xs text-yellow-700">
+                      {selectedRoute.chainControlInfo.locationName &&
+                        (selectedRoute.chainControlInfo.latitude &&
+                        selectedRoute.chainControlInfo.longitude ? (
+                          <a
+                            href={`https://www.google.com/maps/search/?api=1&query=${selectedRoute.chainControlInfo.latitude},${selectedRoute.chainControlInfo.longitude}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1 hover:text-yellow-900 underline"
+                          >
+                            <MapPin className="h-3.5 w-3.5" />
+                            {selectedRoute.chainControlInfo.locationName}
+                            {selectedRoute.chainControlInfo.direction &&
+                              ` (${selectedRoute.chainControlInfo.direction})`}
+                          </a>
+                        ) : (
+                          <span className="flex items-center gap-1">
+                            <MapPin className="h-3.5 w-3.5" />
+                            {selectedRoute.chainControlInfo.locationName}
+                            {selectedRoute.chainControlInfo.direction &&
+                              ` (${selectedRoute.chainControlInfo.direction})`}
+                          </span>
+                        ))}
+                      {selectedRoute.chainControlInfo.effectiveTime && (
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3.5 w-3.5" />
+                          {formatHumanTime(selectedRoute.chainControlInfo.effectiveTime)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </InfoCard>
+            )}
+
+          {/* On Route Alerts */}
+          {onRouteAlerts.length > 0 && (
+            <div>
+              <h3 className="text-xs font-semibold text-stone-500 uppercase tracking-wide mb-3">
+                Affects your route
+              </h3>
+              <div className="space-y-3">
+                {onRouteAlerts.map((alert, index) => {
+                  const incidentChip = getIncidentChip(alert);
+                  const impactChip = getImpactChip(alert.impact);
+                  const IconComponent = incidentChip.icon;
+                  const cardVariant = alert.severity === 'CRITICAL' ? 'danger' : 'warning';
+
+                  return (
+                    <InfoCard key={alert.id || index} variant={cardVariant}>
+                      <div className="flex gap-3">
+                        <div
+                          className={`${alert.severity === 'CRITICAL' ? 'bg-red-600' : 'bg-yellow-600'} rounded-lg w-9 h-9 flex items-center justify-center flex-shrink-0`}
+                        >
+                          <IconComponent className="h-5 w-5 text-white" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span
+                              className={`text-sm font-bold ${alert.severity === 'CRITICAL' ? 'text-red-900' : 'text-yellow-900'}`}
+                            >
+                              {alert.locationDescription
+                                ? `${alert.locationDescription}${alert.incidentType ? ` (${formatEnumValue(alert.incidentType)})` : ''}`
+                                : alert.title}
+                            </span>
+                            {alert.startTime && (
+                              <span
+                                className={`text-xs ${alert.severity === 'CRITICAL' ? 'text-red-600' : 'text-yellow-700'}`}
+                              >
+                                {formatHumanTime(alert.startTime)}
+                              </span>
+                            )}
+                          </div>
+
+                          <p
+                            className={`text-sm leading-relaxed mb-2 ${alert.severity === 'CRITICAL' ? 'text-red-800' : 'text-yellow-800'}`}
+                          >
+                            {alert.description}
+                          </p>
+
+                          <div className="flex flex-wrap gap-2">
+                            {alert.distanceToRouteMeters && alert.classification !== 'ON_ROUTE' && (
+                              <span className="bg-white/60 px-2 py-1 rounded text-xs text-stone-700">
+                                <strong>
+                                  {formatDistanceToRoute(alert.distanceToRouteMeters)}
+                                </strong>
+                              </span>
+                            )}
+                            {impactChip && (
+                              <span
+                                className={`px-2 py-1 rounded text-xs font-medium ${impactChip.color}`}
+                              >
+                                {impactChip.label}
+                              </span>
+                            )}
+                            {alert.metadata &&
+                              Object.entries(alert.metadata).map(([key, value]) => {
+                                const formattedValue = formatMetadataValue(String(value));
+                                if (
+                                  !formattedValue ||
+                                  formattedValue.toLowerCase() === 'none' ||
+                                  formattedValue.toLowerCase() === 'n/a'
+                                ) {
+                                  return null;
+                                }
+                                return (
+                                  <span
+                                    key={key}
+                                    className="bg-white/60 px-2 py-1 rounded text-xs text-stone-700"
+                                  >
+                                    {formattedValue}
+                                  </span>
+                                );
+                              })}
+                          </div>
+                        </div>
+                      </div>
+                    </InfoCard>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Nearby Alerts */}
+          {nearbyAlerts.length > 0 && (
+            <CollapsibleSection
+              title="Nearby Incidents"
+              count={nearbyAlerts.length}
+              countVariant="danger"
+            >
+              {nearbyAlerts
+                .sort((a, b) => {
+                  const severityOrder = {
+                    CRITICAL: 0,
+                    WARNING: 1,
+                    INFO: 2,
+                    ALERT_SEVERITY_UNSPECIFIED: 3,
+                  };
+                  return severityOrder[a.severity] - severityOrder[b.severity];
+                })
+                .map((alert, index) => {
+                  const incidentChip = getIncidentChip(alert);
+                  const IconComponent = incidentChip.icon;
+                  const cardVariant = alert.severity === 'CRITICAL' ? 'danger' : 'default';
+
+                  return (
+                    <InfoCard key={alert.id || index} variant={cardVariant}>
+                      <div className="flex gap-3">
+                        <div
+                          className={`${alert.severity === 'CRITICAL' ? 'bg-red-600' : 'bg-stone-500'} rounded-lg w-9 h-9 flex items-center justify-center flex-shrink-0`}
+                        >
+                          <IconComponent className="h-5 w-5 text-white" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span
+                              className={`text-sm font-bold ${alert.severity === 'CRITICAL' ? 'text-red-900' : 'text-stone-800'}`}
+                            >
+                              {alert.locationDescription
+                                ? `${alert.locationDescription}${alert.incidentType ? ` (${formatEnumValue(alert.incidentType)})` : ''}`
+                                : alert.title}
+                            </span>
+                            {alert.startTime && (
+                              <span
+                                className={`text-xs ${alert.severity === 'CRITICAL' ? 'text-red-600' : 'text-stone-500'}`}
+                              >
+                                {formatHumanTime(alert.startTime)}
+                              </span>
+                            )}
+                          </div>
+
+                          <p
+                            className={`text-sm leading-relaxed mb-2 ${alert.severity === 'CRITICAL' ? 'text-red-800' : 'text-stone-600'}`}
+                          >
+                            {alert.description}
+                          </p>
+
+                          <div className="flex flex-wrap gap-2">
+                            {alert.distanceToRouteMeters && (
+                              <span
+                                className={`${alert.severity === 'CRITICAL' ? 'bg-white/60' : 'bg-stone-100'} px-2 py-1 rounded text-xs ${alert.severity === 'CRITICAL' ? 'text-red-800' : 'text-stone-700'}`}
+                              >
+                                <strong>
+                                  {formatDistanceToRoute(alert.distanceToRouteMeters)}
+                                </strong>
+                              </span>
+                            )}
+                            {alert.metadata &&
+                              Object.entries(alert.metadata).map(([key, value]) => {
+                                const formattedValue = formatMetadataValue(String(value));
+                                if (
+                                  !formattedValue ||
+                                  formattedValue.toLowerCase() === 'none' ||
+                                  formattedValue.toLowerCase() === 'n/a'
+                                ) {
+                                  return null;
+                                }
+                                return (
+                                  <span
+                                    key={key}
+                                    className={`${alert.severity === 'CRITICAL' ? 'bg-white/60' : 'bg-stone-100'} px-2 py-1 rounded text-xs ${alert.severity === 'CRITICAL' ? 'text-red-800' : 'text-stone-700'}`}
+                                  >
+                                    {formattedValue}
+                                  </span>
+                                );
+                              })}
+                          </div>
+
+                          {alert.location && (
+                            <a
+                              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(alert.location)}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={`inline-flex items-center gap-1 text-xs mt-2 ${alert.severity === 'CRITICAL' ? 'text-red-700 hover:text-red-600' : 'text-blue-600 hover:text-blue-700'}`}
+                            >
+                              View on map →
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    </InfoCard>
+                  );
+                })}
+            </CollapsibleSection>
+          )}
+
+          {/* No alerts state */}
+          {onRouteAlerts.length === 0 && nearbyAlerts.length === 0 && (
+            <div className="text-center py-8">
+              <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-3" />
+              <h3 className="font-medium text-stone-900 mb-1">All clear on your route</h3>
+              <p className="text-stone-600 text-sm">No incidents or alerts affecting this route.</p>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/homepage/CurrentConditions.tsx
+++ b/src/components/homepage/CurrentConditions.tsx
@@ -33,6 +33,31 @@ interface ConditionsResponse {
   lastUpdated?: string;
 }
 
+// Road state (open/restricted/closed, travel time, delay) is the road_segment
+// map-layer projection; chain control is the chain_control projection — both
+// GeoJSON FeatureCollections.
+interface RoadSegmentProps {
+  id?: string;
+  headline?: string;
+  status?: string; // OPEN | RESTRICTED | CLOSED
+  areaLabel?: string;
+  road?: { roadId?: string; delayMinutes?: number };
+}
+
+interface ChainControlProps {
+  id?: string;
+  headline?: string;
+  status?: string;
+  category?: string;
+  level?: string;
+  road?: { roadId?: string };
+  chainControl?: { level?: string };
+}
+
+interface GeoJsonFeatureCollection<P> {
+  features?: { properties?: P }[];
+}
+
 // Road incidents and weather alerts are both events on the unified event feed
 // (GET /api/v1/events?layer=…), sharing the common event envelope.
 interface GridEvent {
@@ -48,6 +73,14 @@ interface GridEvent {
 interface GridEventList {
   events?: GridEvent[];
   nextPageToken?: string;
+}
+
+// A road segment normalized for the compact widget.
+interface RoadSeg {
+  label: string;
+  rawStatus: string;
+  delayMinutes: number;
+  chain: string; // 'none' | 'R1' | 'R2' | 'R3'
 }
 
 interface RepeaterInfo {
@@ -108,12 +141,76 @@ const mapGridSeverity = (severity: string | undefined): Alert['severity'] => {
   }
 };
 
-// Humanize a road incident's type/location for the compact list.
-const incidentLabel = (event: GridEvent): string =>
-  event.areaLabel || event.headline || event.summary || 'Road incident';
+// Detect an R1/R2/R3 chain level from whichever free-text field carries it.
+const detectChainShort = (...values: (string | undefined)[]): string => {
+  const s = values.filter(Boolean).join(' ').toUpperCase();
+  if (/\bR3\b/.test(s)) return 'R3';
+  if (/\bR2\b/.test(s)) return 'R2';
+  if (/\bR1\b/.test(s)) return 'R1';
+  return 'none';
+};
 
-// Collect alerts from the event feeds (deduplicated by title). Road incidents
-// and weather alerts are both events now; fire-weather comes from /conditions.
+// Build roadId → chain level from the chain_control layer.
+const buildChainMap = (
+  fc: GeoJsonFeatureCollection<ChainControlProps> | undefined,
+): Record<string, string> => {
+  const map: Record<string, string> = {};
+  for (const feature of fc?.features || []) {
+    const p = feature.properties;
+    if (!p) continue;
+    const roadId = p.road?.roadId || (p.id || '').replace(/^[^:]+:/, '');
+    const chain = detectChainShort(
+      p.chainControl?.level,
+      p.level,
+      p.category,
+      p.status,
+      p.headline,
+    );
+    if (roadId && chain !== 'none') map[roadId] = chain;
+  }
+  return map;
+};
+
+// Normalize road_segment features into compact rows.
+const buildRoadSegments = (
+  fc: GeoJsonFeatureCollection<RoadSegmentProps> | undefined,
+  chainMap: Record<string, string>,
+): RoadSeg[] =>
+  (fc?.features || []).map((feature) => {
+    const p = feature.properties || {};
+    const roadId = p.road?.roadId || (p.id || '').replace(/^[^:]+:/, '');
+    return {
+      label: p.areaLabel || p.headline || 'Route',
+      rawStatus: (p.status || '').toLowerCase(),
+      delayMinutes: p.road?.delayMinutes ?? 0,
+      chain: (roadId && chainMap[roadId]) || 'none',
+    };
+  });
+
+const getRoadStatusText = (road: RoadSeg): string => {
+  if (road.rawStatus === 'closed') return 'Closed';
+  if (road.delayMinutes > 0) return `${road.delayMinutes}min delays`;
+  if (road.chain !== 'none') return 'Chain controls';
+  if (road.rawStatus === 'restricted') return 'Restrictions';
+  return 'Clear';
+};
+
+const getRoadStatusColor = (road: RoadSeg): string => {
+  if (road.rawStatus === 'closed') return 'text-red-700';
+  if (road.delayMinutes > 15) return 'text-red-700';
+  if (road.delayMinutes > 0 || road.chain !== 'none' || road.rawStatus === 'restricted') {
+    return 'text-yellow-700';
+  }
+  return 'text-green-700';
+};
+
+const hasRoadIssue = (road: RoadSeg): boolean =>
+  road.rawStatus === 'closed' ||
+  road.rawStatus === 'restricted' ||
+  road.delayMinutes > 0 ||
+  road.chain !== 'none';
+
+// Collect alerts from the event feeds + fire weather (deduplicated by title).
 const collectAlerts = (
   roadIncidents: GridEvent[],
   weatherAlertEvents: GridEvent[],
@@ -145,7 +242,7 @@ const collectAlerts = (
     pushAlert({
       id: event.id,
       severity: mapGridSeverity(event.severity),
-      title: event.headline || incidentLabel(event),
+      title: event.headline || event.areaLabel || event.summary || 'Road incident',
       description: event.summary || event.description,
       type: 'road',
     });
@@ -167,14 +264,26 @@ const collectAlerts = (
 
 export default function CurrentConditions() {
   const [weatherData, setWeatherData] = useState<ConditionsResponse | null>(null);
+  const [roadSegments, setRoadSegments] = useState<RoadSeg[] | null>(null);
   const [roadIncidents, setRoadIncidents] = useState<GridEvent[]>([]);
   const [weatherAlertEvents, setWeatherAlertEvents] = useState<GridEvent[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
     try {
-      const [conditionsResponse, roadIncidentsResponse, weatherAlertsResponse] = await Promise.all([
-        fetch(`${GRID_API_BASE}/conditions?place=${GRID_AREA}`, {
+      const [
+        conditionsResponse,
+        roadSegmentsResponse,
+        chainControlResponse,
+        roadIncidentsResponse,
+        weatherAlertsResponse,
+      ] = await Promise.all([
+        fetch(`${GRID_API_BASE}/conditions?place=${GRID_AREA}`, { method: 'GET', mode: 'cors' }),
+        fetch(`${GRID_API_BASE}/places/${GRID_AREA}/map/road_segment.geojson`, {
+          method: 'GET',
+          mode: 'cors',
+        }),
+        fetch(`${GRID_API_BASE}/places/${GRID_AREA}/map/chain_control.geojson`, {
           method: 'GET',
           mode: 'cors',
         }),
@@ -188,15 +297,25 @@ export default function CurrentConditions() {
         }),
       ]);
 
-      if (!conditionsResponse.ok || !roadIncidentsResponse.ok || !weatherAlertsResponse.ok) {
+      if (
+        !conditionsResponse.ok ||
+        !roadSegmentsResponse.ok ||
+        !chainControlResponse.ok ||
+        !roadIncidentsResponse.ok ||
+        !weatherAlertsResponse.ok
+      ) {
         throw new Error('Failed to fetch data');
       }
 
       const conditions: ConditionsResponse = await conditionsResponse.json();
+      const segments: GeoJsonFeatureCollection<RoadSegmentProps> =
+        await roadSegmentsResponse.json();
+      const chains: GeoJsonFeatureCollection<ChainControlProps> = await chainControlResponse.json();
       const roads: GridEventList = await roadIncidentsResponse.json();
       const weatherAlerts: GridEventList = await weatherAlertsResponse.json();
 
       setWeatherData(conditions);
+      setRoadSegments(buildRoadSegments(segments, buildChainMap(chains)));
       setRoadIncidents(roads.events || []);
       setWeatherAlertEvents(weatherAlerts.events || []);
     } catch (err) {
@@ -275,35 +394,36 @@ export default function CurrentConditions() {
           <div>
             <h4 className="font-medium text-stone-700 mb-1">Road conditions</h4>
             <div className="space-y-1 ml-2">
-              {roadIncidents.length === 0 ? (
-                <div className="flex justify-between items-center">
-                  <span className="text-stone-600">All routes:</span>
-                  <span className="font-medium text-green-700">Clear</span>
-                </div>
-              ) : (
-                roadIncidents.slice(0, 4).map((event, index) => (
-                  <div
-                    key={event.id || `incident-${index}`}
-                    className="flex justify-between items-center gap-2"
-                  >
-                    <span className="text-stone-600 truncate">{incidentLabel(event)}:</span>
-                    <span
-                      className={`font-medium flex-shrink-0 ${
-                        mapGridSeverity(event.severity) === 'CRITICAL'
-                          ? 'text-red-700'
-                          : 'text-yellow-700'
-                      }`}
-                    >
-                      {(event.category || 'Incident').replace(/^\w/, (c) => c.toUpperCase())}
+              {(() => {
+                if (!roadSegments) {
+                  return (
+                    <div className="flex justify-between items-center">
+                      <span className="text-stone-600">Status:</span>
+                      <span className="font-medium text-stone-500">No data</span>
+                    </div>
+                  );
+                }
+
+                const roadsWithIssues = roadSegments.filter(hasRoadIssue);
+
+                if (roadsWithIssues.length === 0) {
+                  return (
+                    <div className="flex justify-between items-center">
+                      <span className="text-stone-600">All routes:</span>
+                      <span className="font-medium text-green-700">Clear</span>
+                    </div>
+                  );
+                }
+
+                return roadsWithIssues.map((road) => (
+                  <div key={road.label} className="flex justify-between items-center gap-2">
+                    <span className="text-stone-600 truncate">{road.label}:</span>
+                    <span className={`font-medium flex-shrink-0 ${getRoadStatusColor(road)}`}>
+                      {getRoadStatusText(road)}
                     </span>
                   </div>
-                ))
-              )}
-              {roadIncidents.length > 4 && (
-                <div className="text-xs text-stone-500">
-                  +{roadIncidents.length - 4} more incident{roadIncidents.length - 4 > 1 ? 's' : ''}
-                </div>
-              )}
+                ));
+              })()}
             </div>
           </div>
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -21,6 +21,38 @@ export interface Alert {
   metadata?: Record<string, unknown>;
 }
 
+export interface ChainControlInfo {
+  level:
+    | 'CHAIN_CONTROL_LEVEL_UNSPECIFIED'
+    | 'CHAIN_CONTROL_LEVEL_NONE'
+    | 'CHAIN_CONTROL_LEVEL_R1'
+    | 'CHAIN_CONTROL_LEVEL_R2'
+    | 'CHAIN_CONTROL_LEVEL_R3';
+  locationName?: string;
+  latitude?: number;
+  longitude?: number;
+  effectiveTime?: string;
+  direction?: string;
+  description?: string;
+}
+
+export interface RoadSegment {
+  from: string;
+  to: string;
+  status: 'clear' | 'delays' | 'restrictions' | 'closed';
+  delayMinutes?: number;
+  description?: string;
+  alertCount: number;
+  alerts: Alert[];
+  congestionLevel?: string;
+  durationMinutes?: number;
+  distanceKm?: number;
+  chainControl?: string;
+  chainControlInfo?: ChainControlInfo;
+  rawStatus?: string;
+  statusExplanation?: string;
+}
+
 export interface WeatherLocation {
   name: string;
   temperature: number;


### PR DESCRIPTION
## Summary

Refactors the road and weather data integration to use the S.I.E.R.R.A. Grid's new `/api/v1` endpoints, which consolidate road incidents and weather alerts into a unified event feed, and serve road/chain state as GeoJSON map layers instead of a monolithic roads endpoint.

## Key Changes

- **API endpoint migration**: Updated base URL from `/v1` to `/api/v1` and replaced legacy endpoints:
  - `/roads` → `/places/{area}/map/road_segment.geojson` (GeoJSON FeatureCollection)
  - `/weather` → `/conditions` (camelCase fields)
  - Road alerts → `/events?layer=road_incident` (unified event feed)
  - Added `/places/{area}/map/chain_control.geojson` for chain control state

- **Data structure refactoring**:
  - Moved type definitions for `Alert`, `RoadSegment`, `ChainControlInfo`, and `WeatherLocation` to a shared `types.ts` module
  - Replaced snake_case API response interfaces with camelCase (e.g., `weather_data` → `weather`, `temperature_celsius` → `temperatureCelsius`)
  - Introduced GeoJSON-specific interfaces (`RoadSegmentProps`, `ChainControlProps`, `GeoJsonFeatureCollection`)
  - Added `GridEvent` and `GridEventList` interfaces for the unified event envelope

- **Alert transformation logic**:
  - Replaced `transformRoadAlert()` with `transformRoadIncident()` to handle road incidents as Grid events
  - Added `transformFireWeather()` to surface fire-weather state (elevated/red-flag) as alerts when active
  - Unified severity mapping via `mapGridSeverity()` for both road and weather events

- **Chain control handling**:
  - Introduced `detectChainLevel()` helper to extract R1/R2/R3 levels from free-text fields
  - Added `buildChainControlMap()` to normalize chain_control GeoJSON into a roadId-indexed lookup
  - Chain control is now queried separately and merged into road segments by roadId

- **Road segment normalization**:
  - Road segments are now parsed from GeoJSON features with `areaLabel` split into from/to locations
  - Status mapping now considers raw status, delay, chain control, and incident severity
  - Removed inline alert transformation; incidents are now matched to segments via `placeIds` (corridor:{roadId})

- **Fire-weather integration**:
  - Fire-weather state (normal/elevated/red-flag) is now bundled with conditions payload
  - Surfaced as a top-priority alert when state is not normal

- **Component updates**:
  - `RoadWeatherStatus.tsx`: Refactored data fetching to handle 5 parallel requests (conditions, road_segment, chain_control, road_incident, weather_alert)
  - `CurrentConditions.tsx`: Simplified to use the same unified event feed; added `buildRoadSegments()` and `buildChainMap()` helpers for compact widget rendering

## Implementation Details

- Moved `formatHumanTime()` utility to shared `types.ts` for reuse across components
- Road incidents are now attached to segments via `placeIds` matching pattern `corridor:{roadId}` rather than inline arrays
- Chain control map is built once and reused across all road segment transformations
- Fire-weather alerts are deduplicated alongside road and weather alerts in the unified alert list
- Updated source attribution in footer to reflect new data providers (Google Routes, CHP, NWS)

https://claude.ai/code/session_017hrPEQtDw4DG275TsUaSfU